### PR TITLE
Fix typo

### DIFF
--- a/generators/blueprint/templates/component/scripts/bp.js.ejs
+++ b/generators/blueprint/templates/component/scripts/bp.js.ejs
@@ -42,7 +42,7 @@ class <%= bpJsName %> extends Component {
     }
 
 	handleResize = () => {
-		console.log(`Browser was resized and catched by <%= bpJsName %>!`);
+		console.log(`Browser was resized and caught by <%= bpJsName %>!`);
 	};<% } %><% } %>
 
 	/**


### PR DESCRIPTION
Catch - caught - caught => 

cp: http://konjugator.reverso.net/konjugation-englisch-verb-catch.html